### PR TITLE
  feat: デバッグテキスト表示機能を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = app
-SRC = main.c
+SRC = main.c gate.c win.c
 CC = gcc
 MLX_DIR = ./minilibx-linux
 CFLAGS = -Wall -Wextra -Werror -I$(MLX_DIR)

--- a/gate.c
+++ b/gate.c
@@ -5,7 +5,7 @@
 #include "gate.h"
 
 // スレッドで実行されるカウンター関数
-void    *counter_thread(void *arg)
+void *counter_thread(void *arg)
 {
 	t_data  *data = (t_data *)arg;
 

--- a/gate.c
+++ b/gate.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <pthread.h>
+#include "main.h"
+#include "gate.h"
+
+// スレッドで実行されるカウンター関数
+void    *counter_thread(void *arg)
+{
+	t_data  *data = (t_data *)arg;
+
+	data->counter = 0;
+	while (1) {
+		printf("Counter: %ld\n", data->counter);
+		sleep(1); // 1秒待機
+		data->counter++;
+	}
+	return (NULL);
+}
+
+int gate_initialize(t_data *data)
+{
+	pthread_t   thread_id;
+
+	// カウンタースレッドを作成し、data構造体を渡す
+	if (pthread_create(&thread_id, NULL, counter_thread, data) != 0)
+	{
+		perror("pthread_create");
+		return (1);
+	}
+	// スレッドをデタッチし、リソースが自動的に解放されるようにする
+	pthread_detach(thread_id);
+
+	return 0;
+}

--- a/gate.h
+++ b/gate.h
@@ -1,0 +1,4 @@
+#ifndef GATE_H_
+#define GATE_H_
+int gate_initialize(t_data *data);
+#endif//GATE_H_

--- a/main.c
+++ b/main.c
@@ -1,7 +1,9 @@
 #include <mlx.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 
 // mlxポインタをスレッドに渡すための構造体
 typedef struct s_data
@@ -10,12 +12,12 @@ typedef struct s_data
 	void	*win;
 	size_t	counter;
 	size_t  prev_counter;
-}			t_data;
+}           t_data;
 
 // スレッドで実行されるカウンター関数
-void	*counter_thread(void *arg)
+void    *counter_thread(void *arg)
 {
-	t_data	*data = (t_data *)arg;
+	t_data  *data = (t_data *)arg;
 
 	data->counter = 0;
 	while (1) {
@@ -29,17 +31,35 @@ void	*counter_thread(void *arg)
 int render_next_frame(void* arg)
 {
 	t_data *data = (t_data*)arg;
+	char buffer[256];
+
 	if (data->counter != data->prev_counter) {
+		// 画面をクリア
+		mlx_clear_window(data->mlx, data->win);
+		// 表示する文字列を作成
+		sprintf(buffer, "Counter: %ld", data->counter);
+		// 文字列をウィンドウに描画
+		mlx_string_put(data->mlx, data->win, 10, 20, 0xFFFFFF, buffer); // 白色で表示
 		printf("render_next_frame: %ld\n", data->counter);
 		data->prev_counter = data->counter;
 	}
 	return 0;
 }
 
+int	key_press_hook(int keycode, t_data *data)
+{
+	if (keycode == 65307) // 65307 is the keycode for ESC
+	{
+		mlx_destroy_window(data->mlx, data->win);
+		exit(0);
+	}
+	return (0);
+}
+
 int	main(void)
 {
-	t_data		data;
-	pthread_t	thread_id;
+	t_data      data;
+	pthread_t   thread_id;
 
 	// minilibxの初期化
 	data.mlx = mlx_init();
@@ -59,6 +79,7 @@ int	main(void)
 	pthread_detach(thread_id);
 	// イベントループ開始
 	mlx_loop_hook(data.mlx, render_next_frame, (void*)&data);
+	mlx_key_hook(data.win, key_press_hook, &data);
 	// counter_threadでmlx_loop_endが呼ばれると、このループは終了する
 	mlx_loop(data.mlx);
 	// mlxのリソースを解放

--- a/main.c
+++ b/main.c
@@ -1,89 +1,25 @@
-#include <mlx.h>
-#include <pthread.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-
-// mlxポインタをスレッドに渡すための構造体
-typedef struct s_data
-{
-	void	*mlx;
-	void	*win;
-	size_t	counter;
-	size_t  prev_counter;
-}           t_data;
-
-// スレッドで実行されるカウンター関数
-void    *counter_thread(void *arg)
-{
-	t_data  *data = (t_data *)arg;
-
-	data->counter = 0;
-	while (1) {
-		printf("Counter: %ld\n", data->counter);
-		sleep(1); // 1秒待機
-		data->counter++;
-	}
-	return (NULL);
-}
-
-int render_next_frame(void* arg)
-{
-	t_data *data = (t_data*)arg;
-	char buffer[256];
-
-	if (data->counter != data->prev_counter) {
-		// 画面をクリア
-		mlx_clear_window(data->mlx, data->win);
-		// 表示する文字列を作成
-		sprintf(buffer, "Counter: %ld", data->counter);
-		// 文字列をウィンドウに描画
-		mlx_string_put(data->mlx, data->win, 10, 20, 0xFFFFFF, buffer); // 白色で表示
-		printf("render_next_frame: %ld\n", data->counter);
-		data->prev_counter = data->counter;
-	}
-	return 0;
-}
-
-int	key_press_hook(int keycode, t_data *data)
-{
-	if (keycode == 65307) // 65307 is the keycode for ESC
-	{
-		mlx_destroy_window(data->mlx, data->win);
-		exit(0);
-	}
-	return (0);
-}
+#include "main.h"
+#include "gate.h"
+#include "win.h"
 
 int	main(void)
 {
 	t_data      data;
-	pthread_t   thread_id;
-
-	// minilibxの初期化
-	data.mlx = mlx_init();
-	if (!data.mlx)
-		return (1);
-	// 幅800, 高さ600のウィンドウを作成
-	data.win = mlx_new_window(data.mlx, 800, 600, "10-second Window");
-	if (!data.win)
-		return (1);
-	// カウンタースレッドを作成し、data構造体を渡す
-	if (pthread_create(&thread_id, NULL, counter_thread, &data) != 0)
-	{
-		perror("pthread_create");
-		return (1);
-	}
-	// スレッドの終了を待つ
-	pthread_detach(thread_id);
+	int result;
+	
+	result = win_initialize(&data);
+	if (result != 0)
+		return result;
+	
+	result = gate_initialize(&data);
+	if (result != 0)
+		return result;
+	
 	// イベントループ開始
-	mlx_loop_hook(data.mlx, render_next_frame, (void*)&data);
-	mlx_key_hook(data.win, key_press_hook, &data);
-	// counter_threadでmlx_loop_endが呼ばれると、このループは終了する
-	mlx_loop(data.mlx);
-	// mlxのリソースを解放
-	mlx_destroy_display(data.mlx);
-	printf("Program finished.\n");
+	win_loop(&data);
+
+	printf("Program finished gracefully.\n");
+	
 	return (0);
 }

--- a/main.c
+++ b/main.c
@@ -8,7 +8,7 @@ int	main(void)
 	t_data      data;
 	int result;
 	
-	result = win_initialize(&data);
+	result = win_initialize(&data, 800, 600);
 	if (result != 0)
 		return result;
 	

--- a/main.h
+++ b/main.h
@@ -1,0 +1,13 @@
+#ifndef MAIN_H_
+#define MAIN_H_
+#include <stdlib.h>
+// mlxポインタをスレッドに渡すための構造体
+typedef struct s_data
+{
+	void	*mlx;
+	void	*win;
+	size_t	counter;
+	size_t  prev_counter;
+}           t_data;
+
+#endif//MAIN_H_

--- a/win.c
+++ b/win.c
@@ -1,16 +1,35 @@
 #include <mlx.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include "win.h"
 
-int win_initialize(t_data *data)
+void debug_print(t_data *data, const char *line, ...)
+{
+	static int y = 10;
+	char buffer[256];
+	
+	// 表示する文字列を作成
+	va_list ap;
+	va_start(ap, line);
+	vsnprintf(buffer, sizeof(buffer), line, ap);
+	va_end(ap);
+
+	// 文字列をウィンドウに描画
+	mlx_string_put(data->mlx, data->win, 20, y, 0xFFFFFF, buffer); // 白色で表示
+
+	y += 10;
+}
+
+int win_initialize(t_data *data, int width, int height)
 {
 	// minilibxの初期化
 	data->mlx = mlx_init();
 	if (!data->mlx)
 		return (1);
-	// 幅800, 高さ600のウィンドウを作成
-	data->win = mlx_new_window(data->mlx, 800, 600, "10-second Window");
+
+	// 幅 width, 高さ height のウィンドウを作成
+	data->win = mlx_new_window(data->mlx, width, height, "10-second Window");
 	if (!data->win)
 		return (1);
 	    
@@ -20,15 +39,12 @@ int win_initialize(t_data *data)
 int render_next_frame(void* arg)
 {
 	t_data *data = (t_data*)arg;
-	char buffer[256];
 
 	if (data->counter != data->prev_counter) {
 		// 画面をクリア
 		mlx_clear_window(data->mlx, data->win);
-		// 表示する文字列を作成
-		sprintf(buffer, "Counter: %ld", data->counter);
-		// 文字列をウィンドウに描画
-		mlx_string_put(data->mlx, data->win, 10, 20, 0xFFFFFF, buffer); // 白色で表示
+
+		debug_print(data, "Counter: %ld", data->counter);
 		printf("render_next_frame: %ld\n", data->counter);
 		data->prev_counter = data->counter;
 	}

--- a/win.c
+++ b/win.c
@@ -1,0 +1,57 @@
+#include <mlx.h>
+#include <string.h>
+#include <stdio.h>
+#include "win.h"
+
+int win_initialize(t_data *data)
+{
+	// minilibxの初期化
+	data->mlx = mlx_init();
+	if (!data->mlx)
+		return (1);
+	// 幅800, 高さ600のウィンドウを作成
+	data->win = mlx_new_window(data->mlx, 800, 600, "10-second Window");
+	if (!data->win)
+		return (1);
+	    
+    return 0;
+}
+
+int render_next_frame(void* arg)
+{
+	t_data *data = (t_data*)arg;
+	char buffer[256];
+
+	if (data->counter != data->prev_counter) {
+		// 画面をクリア
+		mlx_clear_window(data->mlx, data->win);
+		// 表示する文字列を作成
+		sprintf(buffer, "Counter: %ld", data->counter);
+		// 文字列をウィンドウに描画
+		mlx_string_put(data->mlx, data->win, 10, 20, 0xFFFFFF, buffer); // 白色で表示
+		printf("render_next_frame: %ld\n", data->counter);
+		data->prev_counter = data->counter;
+	}
+	return 0;
+}
+
+int	key_press_hook(int keycode, t_data *data)
+{
+	if (keycode == 65307) // 65307 is the keycode for ESC
+	{
+		// ループを正常に終了させる
+		mlx_loop_end(data->mlx);
+	}
+	return (0);
+}
+
+void win_loop(t_data *data)
+{
+	mlx_loop_hook(data->mlx, render_next_frame, data);
+	mlx_key_hook(data->win, key_press_hook, data);
+	// mlx_loop_endが呼ばれると、このループは終了する
+	mlx_loop(data->mlx);
+	// --- クリーンアップ処理 ---
+	mlx_destroy_window(data->mlx, data->win);
+	mlx_destroy_display(data->mlx);
+}

--- a/win.h
+++ b/win.h
@@ -2,7 +2,7 @@
 #define WIN_H_
 #include "main.h"
 
-int win_initialize(t_data *data);
+int win_initialize(t_data *data, int width, int height);
 void win_loop(t_data *data);
 
 #endif//WIN_H_

--- a/win.h
+++ b/win.h
@@ -1,0 +1,8 @@
+#ifndef WIN_H_
+#define WIN_H_
+#include "main.h"
+
+int win_initialize(t_data *data);
+void win_loop(t_data *data);
+
+#endif//WIN_H_


### PR DESCRIPTION
開発中のデバッグを容易にするため、任意のフォーマットで文字列をウィンドウに表示する機能を追加しました。
   - win.c に、可変長引数を受け取って文字列を描画する debug_print 関数を追加
   - win_initialize 関数で、ウィンドウの幅と高さを引数で指定できるように変更
   - render_next_frame 内で、カウンターの値を新しい debug_print 関数を使って表示するように修正

Closes #1 